### PR TITLE
Simplify checkout process and support multiple patch files

### DIFF
--- a/.github/workflows/autopatch.yml
+++ b/.github/workflows/autopatch.yml
@@ -9,9 +9,8 @@ on:
     - cron: '0 7 * * *'
 
 permissions:
-  # write is done via deploy key set in secrets.DEPLOY_KEY
-  # which must have write access to the repository.
-  contents: read
+  # read and write is done via deploy key set in secrets.DEPLOY_KEY.
+  contents: none
 
 jobs:
   build:
@@ -21,19 +20,8 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
         with:
+          ssh-key: ${{secrets.DEPLOY_KEY}}
           fetch-depth: 0
-      - name: Save deploy key
+      - name: Auto-patch upstream tag
         run: |
-          echo "${DEPLOY_KEY}" > "${RUNNER_TEMP}/deploy.key"
-          chmod 0600 "${RUNNER_TEMP}/deploy.key"
-        env:
-          DEPLOY_KEY: ${{secrets.DEPLOY_KEY}}
-      - name: Auto-patch branch "no-thread"
-        run: |
-          git remote set-url origin git@github.com:pjbgf/git2go.git
-          export GIT_SSH_COMMAND="ssh -i ${RUNNER_TEMP}/deploy.key -o IdentitiesOnly=yes"
           patch/auto-patch.sh
-      - name: Clean-up
-        if: always()
-        run: |
-          rm -rf "${RUNNER_TEMP}/deploy.key"

--- a/patch/auto-patch.sh
+++ b/patch/auto-patch.sh
@@ -2,42 +2,51 @@
 
 set -euxo pipefail
 
-tag_suffix="-nothread-check"
+tag_suffix="-flux"
 
 initial_branch="$(git rev-parse --abbrev-ref HEAD)"
 repo_root="$(git rev-parse --show-toplevel)"
-patch=$(cat "${repo_root}/patch/nothread.patch")
 
 # Latest upstream tag within tag pattern.
-upstream_tag="$(git ls-remote https://github.com/libgit2/git2go "refs/tags/v33.0.*" | cut --delimiter='/' --fields=3 | sort -u | tail -n1)"
-if [ "" -eq "${upstream_tag}" ]; then
+upstream_tag=$(git ls-remote https://github.com/libgit2/git2go "refs/tags/v33.0.*" | cut --delimiter='/' --fields=3 | sort -u | tail -n1)
+if [ -z "${upstream_tag}" ]; then
     echo "error finding latest upstream tag"
     exit 1
 fi
 
 new_tag="${upstream_tag}${tag_suffix}"
 
-# Only tag if upstream has a newer tag that wasn't autopatched yet
+# Only tag if upstream has a newer tag that wasn't autopatched yet.
 if [ -z $(git tag -l "${new_tag}") ]; then
-    # fetch upstream and create branch off latest tag.
+    # Fetch upstream and create branch off latest tag.
     git remote add git2go_upstream https://github.com/libgit2/git2go
-    git fetch git2go_upstream    
-    git checkout -B no-thread "refs/tags/${upstream_tag}"
+    git fetch git2go_upstream
 
-    # patch latest tag
-    echo "${patch}" | git apply
-    git add git.go
-    git config --global user.email "pjbgf@linux.com"
-    git config --global user.name "git2go auto-patcher"
-    git commit -m "Auto-patch libgit2 nothread support"
+    git config --global user.email "fluxcdbot@users.noreply.github.com"
+    git config --global user.name "fluxcdbot"
+    
+    # Create a temporary dir to store patches before checking out
+    # upstream tag. Then ensures said dir is removed.
+    TMPDIR="$(mktemp -d /tmp/auto-patch_XXXXXX)"
+    trap "rm -rf ${TMPDIR}" EXIT
+    cp "${repo_root}"/patch/*.patch "${TMPDIR}"
 
-    # tag current repo and push tag
+    git checkout -B auto-patch "refs/tags/${upstream_tag}"
+
+    # Apply patch files.
+    for PATCH_FILE in "${TMPDIR}"/*.patch; do
+        git apply < "${PATCH_FILE}"
+        git add --all
+        git commit -m "Apply $(basename ${PATCH_FILE})"
+    done
+
+    # Tag current repo and push tag.
     git tag "${new_tag}"
     git push origin "${new_tag}"
 
-    # revert branch switch and remote creation
+    # Revert branch switch and remove temporary remote.
     git checkout "${initial_branch}"
     git remote rm git2go_upstream
 else
-    echo "Skipping as latest tag is already patched"
+    echo "Skipping as ${new_tag} already exists"
 fi


### PR DESCRIPTION
- The auto-patch process now supports multiple patch files.
- The version suffix changed to `-flux`.
- Set deploy key via actions/checkout.
- Update target repository and author names.

Relates to https://github.com/fluxcd/pkg/issues/363